### PR TITLE
Add glide version as env property

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,14 @@
 FROM golang:1.6
 
-ENV GO15VENDOREXPERIMENT 1
-ENV VERSION 1.0.1
+ENV GLIDE_VERSION 0.10.2
+ENV APP_VERSION 1.0.2
 
-ADD https://github.com/Masterminds/glide/releases/download/0.10.2/glide-0.10.2-linux-amd64.tar.gz /tmp/glide-0.10.2-linux-amd64.tar.gz
+ADD https://github.com/Masterminds/glide/releases/download/${GLIDE_VERSION}/glide-${GLIDE_VERSION}-linux-amd64.tar.gz /tmp/glide-${GLIDE_VERSION}-linux-amd64.tar.gz
 RUN cd /tmp && \
-    tar -zxvf /tmp/glide-0.10.2-linux-amd64.tar.gz && \
+    tar -zxvf /tmp/glide-${GLIDE_VERSION}-linux-amd64.tar.gz && \
     cp /tmp/linux-amd64/glide /usr/local/bin/glide && \
     chmod 755 /usr/local/bin/glide && \
-    rm /tmp/glide-0.10.2-linux-amd64.tar.gz && rm -rf /tmp/linux-amd64/
+    rm /tmp/glide-${GLIDE_VERSION}-linux-amd64.tar.gz && rm -rf /tmp/linux-amd64/
 
 COPY . /go/src/github.com/apiaryio/heroku-datadog-drain-go
 


### PR DESCRIPTION
- add `GLIDE_VERSION` env property for glide version
- remove `GO15VENDOREXPERIMENT` we don't need for 1.6
