### PR TITLE
fixed server.go to validate statsd var instead of port

### DIFF
--- a/server.go
+++ b/server.go
@@ -89,7 +89,7 @@ func loadServerCtx() *ServerCtx {
 	}
 
 	statsd := os.Getenv("STATSD_URL")
-	if port != "" {
+	if statsd != "" {
 		s.StatsdUrl = statsd
 	}
 


### PR DESCRIPTION
When defining STATSD_URL environment variable, heroku-datadog-drain won't use it because it was validating the wrong var, 'port' instead of 'statsd'.

It was a small fix to server.go file 😄 
