### PR TITLE
Support broken logfmt lines

### DIFF
--- a/logproc.go
+++ b/logproc.go
@@ -51,7 +51,10 @@ func parseMetrics(typ int, ld *logData, data *string, out chan *logMetrics) {
 
 	lm := logMetrics{typ, ld.app, ld.tags, ld.prefix, make(map[string]logValue, 5)}
 	if err := logfmt.Unmarshal([]byte(*data), &lm); err != nil {
-		log.Fatalf("err=%q", err)
+		log.WithFields(log.Fields{
+			"err": err,
+		}).Warn()
+		return
 	}
 	if source, ok := lm.metrics["source"]; ok {
 		tags := append(*lm.tags, "type:"+dynoNumber.ReplaceAllString(source.Val, ""))

--- a/logproc_test.go
+++ b/logproc_test.go
@@ -11,7 +11,8 @@ func TestLogProc(t *testing.T) {
 
 	lines := strings.Split(`255 <158>1 2015-04-02T11:52:34.520012+00:00 host heroku router - at=info method=POST path="/users" host=myapp.com request_id=c1806361-2081-42e7-a8aa-92b6808eac8e fwd="24.76.242.18" dyno=web.1 connect=1ms service=37ms status=201 bytes=828
 229 <45>1 2015-04-02T11:48:16.839257+00:00 host heroku web.1 - source=web.1 dyno=heroku.35930502.b9de5fce-44b7-4287-99a7-504519070cba sample#load_avg_1m=0.01 sample#load_avg_5m=0.02 sample#load_avg_15m=0.03
-222 <134>1 2015-04-07T16:01:43.517062+00:00 host heroku api - Scale to mailer=1, web=3 by someuser@gmail.com`, "\n")
+222 <134>1 2015-04-07T16:01:43.517062+00:00 host heroku api - Scale to mailer=1, web=3 by someuser@gmail.com
+222 <134>1 2015-04-07T16:01:43.517062+00:00 host heroku api - this_is="broken`, "\n")
 
 	app := "test"
 	tags := []string{"tag1", "tag2"}


### PR DESCRIPTION
Sometimes Heroku doesn't emit valid logfmt-compliant log lines, which results in crashes:

```
Oct 25 08:17:44 xxx app/web.1:  time="2016-10-25T08:17:43Z" level=fatal msg="err=\"logfmt: unterminated string\""  
Oct 25 08:17:44 xxx heroku/web.1:  Process exited with status 1 
```

This makes the drain keep churning along.
