### PR TITLE
Optional tag exclusion

### DIFF
--- a/client.go
+++ b/client.go
@@ -24,12 +24,13 @@ var customMetricsKeys = []string{"media_type", "output_type", "route"}
 
 type Client struct {
 	*statsd.Client
+	ExcludedTags map[string]bool
 }
 
 func statsdClient(addr string) (*Client, error) {
 
 	c, err := statsd.New(addr)
-	return &Client{c}, err
+	return &Client{c, make(map[string]bool)}, err
 }
 
 func (c *Client) sendToStatsd(in chan *logMetrics) {
@@ -64,14 +65,20 @@ func (c *Client) sendToStatsd(in chan *logMetrics) {
 	}
 }
 
-func (c *Client) sendRouterMsg(data *logMetrics) {
-
-	tags := *data.tags
-	for _, mk := range routerMetricsKeys {
-		if v, ok := data.metrics[mk]; ok {
+func (c *Client) extractTags(tags []string, permittedTags []string, metrics map[string]logValue) []string {
+	for _, mk := range permittedTags {
+		if c.ExcludedTags[mk] {
+			continue
+		}
+		if v, ok := metrics[mk]; ok {
 			tags = append(tags, mk+":"+v.Val)
 		}
 	}
+	return tags
+}
+
+func (c *Client) sendRouterMsg(data *logMetrics) {
+	tags := c.extractTags(*data.tags, routerMetricsKeys, data.metrics)
 
 	log.WithFields(log.Fields{
 		"app":    *data.app,
@@ -115,13 +122,7 @@ func (c *Client) sendRouterMsg(data *logMetrics) {
 }
 
 func (c *Client) sendSampleMsg(data *logMetrics) {
-
-	tags := *data.tags
-	for _, mk := range sampleMetricsKeys {
-		if v, ok := data.metrics[mk]; ok {
-			tags = append(tags, mk+":"+v.Val)
-		}
-	}
+	tags := c.extractTags(*data.tags, sampleMetricsKeys, data.metrics)
 
 	log.WithFields(log.Fields{
 		"app":    *data.app,

--- a/client_test.go
+++ b/client_test.go
@@ -88,7 +88,6 @@ func TestStatsdClient(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// c.ExcludedTags = map[string]bool{"path": true}
 	c.ExcludedTags["path"] = true
 
 	out := make(chan *logMetrics)

--- a/client_test.go
+++ b/client_test.go
@@ -23,8 +23,10 @@ var statsdTests = []struct {
 			&prefix,
 			map[string]logValue{
 				"at":      {"info", ""},
+				"path":    {"/foo", ""},
 				"connect": {"1", "ms"},
 				"service": {"37", "ms"},
+				"garbage": {"bar", ""},
 			},
 		},
 		Expected: []string{
@@ -85,6 +87,9 @@ func TestStatsdClient(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	// c.ExcludedTags = map[string]bool{"path": true}
+	c.ExcludedTags["path"] = true
 
 	out := make(chan *logMetrics)
 	defer close(out)

--- a/server.go
+++ b/server.go
@@ -151,6 +151,12 @@ func main() {
 		log.WithField("statsdUrl", s.StatsdUrl).Fatal("Could not connect to statsd")
 	}
 
+	if v := os.Getenv("EXCLUDED_TAGS"); v != "" {
+		for _, t := range strings.Split(v, ",") {
+			c.ExcludedTags[t] = true
+		}
+	}
+
 	r := gin.Default()
 	r.GET("/status", func(c *gin.Context) {
 		c.String(200, "OK")


### PR DESCRIPTION
- removes dead code for "metric messages" which weren't being used.
- adds support for the `EXCLUDED_TAGS` to avoid sending particular tags to Datadog.

The rationale for this second point is that the `path=` tag in Heroku logs includes the full HTTP path - including, for instance, query parameters. This makes is very easy to swarm Datadog with numerous distinct tag/value pairs; and Datadog has a hard limit of 1000 such distinct pairs. When the limit is breached, they blacklist the entire metric.