### PR TITLE
chore: add logging to sending event

### DIFF
--- a/client.go
+++ b/client.go
@@ -160,6 +160,11 @@ func (c *Client) sendScalingMsg(data *logMetrics) {
 
 	for _, v := range data.events {
 		c.SimpleEvent("heroku/api: "+*data.app, v)
+		log.WithFields(log.Fields{
+			"type":  "event",
+			"app":   *data.app,
+			"value": v,
+		}).Info("Event sent")
 	}
 
 	for _, mk := range scalingMetricsKeys {


### PR DESCRIPTION
We don't see events in Datadog. I add this logging to monitoring events on heroku logs.