### PR TITLE
fix: parse heroku api messages

### DIFF
--- a/client.go
+++ b/client.go
@@ -159,7 +159,7 @@ func (c *Client) sendScalingMsg(data *logMetrics) {
 	}).Debug("sendScalingMsg")
 
 	for _, v := range data.events {
-		c.Event(statsd.Event{
+		c.Event(&statsd.Event{
 			Title: "heroku/api: " + *data.app,
 			Text:  v,
 			Tags:  tags,

--- a/client.go
+++ b/client.go
@@ -159,7 +159,12 @@ func (c *Client) sendScalingMsg(data *logMetrics) {
 	}).Debug("sendScalingMsg")
 
 	for _, v := range data.events {
-		c.SimpleEvent("heroku/api: "+*data.app, v)
+		c.Event(statsd.Event{
+			Title: "heroku/api: " + *data.app,
+			Text:  v,
+			Tags:  tags,
+		})
+
 		log.WithFields(log.Fields{
 			"type":  "event",
 			"app":   *data.app,

--- a/logproc.go
+++ b/logproc.go
@@ -103,10 +103,14 @@ func logProcess(in chan *logData, out chan *logMetrics) {
 				parseMetrics(sampleMsg, data, &output[1], out)
 			}
 		} else if headers[1] == "app" {
-			dynoType := dynoNumber.ReplaceAllString(headers[2], "")
-			tags := append(*data.tags, "source:"+headers[2], "type:"+dynoType)
-			data.tags = &tags
-			parseMetrics(metricsTag, data, &output[1], out)
+			if headers[2] == "api" {
+				parseMetrics(scalingMsg, data, &output[1], out)
+			} else {
+				dynoType := dynoNumber.ReplaceAllString(headers[2], "")
+				tags := append(*data.tags, "source:"+headers[2], "type:"+dynoType)
+				data.tags = &tags
+				parseMetrics(metricsTag, data, &output[1], out)
+			}
 		}
 	}
 }

--- a/logproc_test.go
+++ b/logproc_test.go
@@ -20,9 +20,9 @@ func TestLogProc(t *testing.T) {
 	tags := []string{"tag1", "tag2"}
 	prefix := "prefix."
 	s := loadServerCtx()
-	s.in = make(chan *logData, 3)
+	s.in = make(chan *logData, 6)
 	defer close(s.in)
-	s.out = make(chan *logMetrics, 3)
+	s.out = make(chan *logMetrics, 6)
 	defer close(s.out)
 
 	go logProcess(s.in, s.out)

--- a/logproc_test.go
+++ b/logproc_test.go
@@ -12,7 +12,9 @@ func TestLogProc(t *testing.T) {
 	lines := strings.Split(`255 <158>1 2015-04-02T11:52:34.520012+00:00 host heroku router - at=info method=POST path="/users" host=myapp.com request_id=c1806361-2081-42e7-a8aa-92b6808eac8e fwd="24.76.242.18" dyno=web.1 connect=1ms service=37ms status=201 bytes=828
 229 <45>1 2015-04-02T11:48:16.839257+00:00 host heroku web.1 - source=web.1 dyno=heroku.35930502.b9de5fce-44b7-4287-99a7-504519070cba sample#load_avg_1m=0.01 sample#load_avg_5m=0.02 sample#load_avg_15m=0.03
 222 <134>1 2015-04-07T16:01:43.517062+00:00 host heroku api - Scale to mailer=1, web=3 by someuser@gmail.com
-222 <134>1 2015-04-07T16:01:43.517062+00:00 host heroku api - this_is="broken`, "\n")
+222 <134>1 2015-04-07T16:01:43.517062+00:00 host heroku api - this_is="broken
+222 <134>1 2017-05-13T15:10:41.908615+00:00 host app api - Deploy b400183 by user someuser@gmail.com
+222 <134>1 2017-05-13T15:35:33.787162+00:00 host app api - Scaled to web@3:Performance-L worker@5:Standard-2X by user someuser@gmail.com`, "\n")
 
 	app := "test"
 	tags := []string{"tag1", "tag2"}
@@ -38,6 +40,16 @@ func TestLogProc(t *testing.T) {
 	res = <-s.out
 	if res.typ != sampleMsg {
 		t.Error("result must be SAMPLE")
+	}
+
+	res = <-s.out
+	if res.typ != scalingMsg {
+		t.Error("result must be SCALE")
+	}
+
+	res = <-s.out
+	if res.typ != scalingMsg {
+		t.Error("result must be SCALE")
 	}
 
 	res = <-s.out

--- a/server_test.go
+++ b/server_test.go
@@ -57,6 +57,15 @@ var fullTests = []struct {
 			"app.metric.eventLoop.max.ms:5008.000000|g|#source:web.1,type:web,route:/parser",
 		},
 	},
+	{
+		cnt: 3,
+		Req: ``,
+		Expected: []string{
+			"_e{16,46}:heroku/api: test|Scaled to web@3:Performance-L worker@5:Standard-2X by user someuser@gmail.com",
+			"heroku.dyno.web:3.000000|g",
+			"heroku.dyno.worker:5.000000|g",
+		},
+	},
 }
 
 func TestStatusRequest(t *testing.T) {


### PR DESCRIPTION
I tried to get scaling message reporting work and after long time tries and error, I found that we are expecting the wrong header. 

From what I see, scaling messages appears in logs under "host app api" and not "host heroku api" as we are expecting.

So, I've fixed this add a few more specs.