### PR TITLE
Fixing the scale events support

### DIFF
--- a/logproc_test.go
+++ b/logproc_test.go
@@ -11,7 +11,7 @@ func TestLogProc(t *testing.T) {
 
 	lines := strings.Split(`255 <158>1 2015-04-02T11:52:34.520012+00:00 host heroku router - at=info method=POST path="/users" host=myapp.com request_id=c1806361-2081-42e7-a8aa-92b6808eac8e fwd="24.76.242.18" dyno=web.1 connect=1ms service=37ms status=201 bytes=828
 229 <45>1 2015-04-02T11:48:16.839257+00:00 host heroku web.1 - source=web.1 dyno=heroku.35930502.b9de5fce-44b7-4287-99a7-504519070cba sample#load_avg_1m=0.01 sample#load_avg_5m=0.02 sample#load_avg_15m=0.03
-222 <134>1 2015-04-07T16:01:43.517062+00:00 host heroku api - Scale to mailer=1, web=3 by someuser@gmail.com
+222 <134>1 2017-05-13T15:35:33.787162+00:00 host app api - Scaled to mailer@3:Performance-L web@5:Standard-2X by user someuser@gmail.com
 222 <134>1 2015-04-07T16:01:43.517062+00:00 host heroku api - this_is="broken
 222 <134>1 2015-04-07T16:01:43.517062+00:00 host app api - Release v138 created by user foo@bar`, "\n")
 

--- a/server_test.go
+++ b/server_test.go
@@ -35,9 +35,9 @@ var fullTests = []struct {
 	},
 	{
 		cnt: 3,
-		Req: `222 <134>1 2015-04-07T16:01:43.517062+00:00 host heroku api - Scale to mailer=1, web=3 by someuser@gmail.com`,
+		Req: `222 <134>1 2015-04-07T16:01:43.517062+00:00 host app api - Scaled to web@3:Performance-L mailer@1:Standard-2X by user someuser@gmail.com`,
 		Expected: []string{
-			"_e{16,46}:heroku/api: test|Scale to mailer=1, web=3 by someuser@gmail.com",
+			"_e{16,77}:heroku/api: test|Scaled to web@3:Performance-L mailer@1:Standard-2X by user someuser@gmail.com",
 			"heroku.dyno.mailer:1.000000|g",
 			"heroku.dyno.web:3.000000|g",
 		},


### PR DESCRIPTION
this should be compliant with current format of heroku loglines regarding scaling

replaces https://github.com/apiaryio/heroku-datadog-drain-golang/pull/44