### PR TITLE
Adding support for counters, histograms and additional alias for gauge

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,14 @@ If you want to log some custom metrics just format the log line like following:
 ```
 app web.1 - info: responseLogger: metric#tag#route=/parser metric#request_id=11747467-f4ce-4b06-8c99-92be968a02e3 metric#request_length=541 metric#response_length=5163 metric#parser_time=5ms metric#eventLoop.count=606 metric#eventLoop.avg_ms=515.503300330033 metric#eventLoop.p50_ms=0.8805309734513275 metric#eventLoop.p95_ms=3457.206896551724 metric#eventLoop.p99_ms=3457.206896551724 metric#eventLoop.max_ms=5008
 ```
-We support `metric#` for values and `metric#tag` for tags.
+We support:
+
+ * `metric#` and `sample#` for gauges 
+ * `metric#tag` for tags.
+ * `count#` for counter increments
+ * `measure#` for histograms
+
+more info [here](https://docs.datadoghq.com/guides/dogstatsd/#data-types)
 
 ## Overriding prefix and tags with drain query params
 
@@ -94,4 +101,3 @@ To change the prefix use the drain of form:
 
 To change tags use the drain of form:
 `https://<your-app-slug>:<password>@<this-log-drain-app-slug>.herokuapp.com?tags=xyz,abcd`
-

--- a/client.go
+++ b/client.go
@@ -5,6 +5,7 @@ import (
 	log "github.com/Sirupsen/logrus"
 	"strconv"
 	"strings"
+	"errors"
 )
 
 const sampleRate = 1.0
@@ -193,6 +194,15 @@ func (c *Client) sendScalingMsg(data *logMetrics) {
 	}
 }
 
+func (c *Client) sendMetric(metricType string, metricName string, value float64, tags []string) error {
+	switch metricType {
+	case "metric", "sample": return c.Gauge(metricName, value, tags, sampleRate)
+	case "measure": return c.Histogram(metricName, value, tags, sampleRate)
+	case "count": return c.Count(metricName, int64(value), tags, sampleRate)
+	default: return errors.New("Unknown metric type"+metricType)
+	}
+}
+
 func (c *Client) sendMetricsWithTags(data *logMetrics) {
 	tags := *data.tags
 
@@ -220,8 +230,10 @@ Tags:
 	for k, v := range data.metrics {
 		if strings.Index(k, "#") != -1 {
 			if vnum, err := strconv.ParseFloat(v.Val, 10); err == nil {
-				m := strings.Replace(strings.Split(k, "#")[1], "_", ".", -1)
-				err = c.Gauge(*data.prefix+"app.metric."+m, vnum, tags, sampleRate)
+				keySplit := strings.Split(k, "#")
+				metricType := keySplit[0]
+				m := strings.Replace(keySplit[1], "_", ".", -1)
+				err = c.sendMetric(metricType, *data.prefix+"app.metric."+m, vnum, tags)
 				if err != nil {
 					log.WithField("error", err).Warning("Failed to send Gauge")
 				}

--- a/client_test.go
+++ b/client_test.go
@@ -39,6 +39,70 @@ var statsdTests = []struct {
 	{
 		cnt: 1,
 		m: logMetrics{
+			metricsTag,
+			&app,
+			&tags,
+			&prefix,
+			map[string]logValue{
+				"metric#load_avg_2m": {"0.01", ""},
+			},
+			events,
+		},
+		Expected: []string{
+			"prefix.app.metric.load.avg.2m:0.010000|g|#tag1,tag2",
+		},
+	},
+	{
+		cnt: 1,
+		m: logMetrics{
+			metricsTag,
+			&app,
+			&tags,
+			&prefix,
+			map[string]logValue{
+				"sample#load_avg_1m": {"0.01", ""},
+			},
+			events,
+		},
+		Expected: []string{
+			"prefix.app.metric.load.avg.1m:0.010000|g|#tag1,tag2",
+		},
+	},
+	{
+		cnt: 1,
+		m: logMetrics{
+			metricsTag,
+			&app,
+			&tags,
+			&prefix,
+			map[string]logValue{
+				"count#clicks": {"1", ""},
+			},
+			events,
+		},
+		Expected: []string{
+			"prefix.app.metric.clicks:1|c|#tag1,tag2",
+		},
+	},
+	{
+		cnt: 1,
+		m: logMetrics{
+			metricsTag,
+			&app,
+			&tags,
+			&prefix,
+			map[string]logValue{
+				"measure#temperature": {"1.3", ""},
+			},
+			events,
+		},
+		Expected: []string{
+			"prefix.app.metric.temperature:1.300000|h|#tag1,tag2",
+		},
+	},
+	{
+		cnt: 1,
+		m: logMetrics{
 			sampleMsg,
 			&app,
 			&tags,


### PR DESCRIPTION
the idea is to use the first element of the metric key as a differentiator for metric types. I am using the convention used by Librato: https://devcenter.heroku.com/articles/librato#custom-log-based-metrics to give users ability to transition between those two solutions.