### PR TITLE
Group http statuses into families

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -27,13 +27,14 @@ var statsdTests = []struct {
 				"path":    {"/foo", ""},
 				"connect": {"1", "ms"},
 				"service": {"37", "ms"},
+				"status": {"401", ""},
 				"garbage": {"bar", ""},
 			},
 			events,
 		},
 		Expected: []string{
-			"prefix.heroku.router.request.connect:1.000000|h|#tag1,tag2,at:info",
-			"prefix.heroku.router.request.service:37.000000|h|#tag1,tag2,at:info",
+			"prefix.heroku.router.request.connect:1.000000|h|#at:info,status:401,tag1,tag2,statusFamily:4xx",
+			"prefix.heroku.router.request.service:37.000000|h|#at:info,status:401,tag1,tag2,statusFamily:4xx",
 		},
 	},
 	{
@@ -114,7 +115,7 @@ var statsdTests = []struct {
 			events,
 		},
 		Expected: []string{
-			"prefix.heroku.dyno.load.avg.1m:0.010000|g|#tag1,tag2,source:web1",
+			"prefix.heroku.dyno.load.avg.1m:0.010000|g|#source:web1,tag1,tag2",
 		},
 	},
 	{

--- a/server_test.go
+++ b/server_test.go
@@ -22,15 +22,15 @@ var fullTests = []struct {
 		cnt: 2,
 		Req: `255 <158>1 2015-04-02T11:52:34.520012+00:00 host heroku router - at=info method=POST path="/users" host=myapp.com request_id=c1806361-2081-42e7-a8aa-92b6808eac8e fwd="24.76.242.18" dyno=web.1 connect=1ms service=37ms status=201 bytes=828`,
 		Expected: []string{
-			"heroku.router.request.connect:1.000000|h|#dyno:web.1,method:POST,status:201,path:/users,host:myapp.com,at:info",
-			"heroku.router.request.service:37.000000|h|#dyno:web.1,method:POST,status:201,path:/users,host:myapp.com,at:info",
+			"heroku.router.request.connect:1.000000|h|#at:info,dyno:web.1,host:myapp.com,method:POST,path:/users,status:201,statusFamily:2xx",
+			"heroku.router.request.service:37.000000|h|#at:info,dyno:web.1,host:myapp.com,method:POST,path:/users,status:201,statusFamily:2xx",
 		},
 	},
 	{
 		cnt: 1,
 		Req: `229 <45>1 2015-04-02T11:48:16.839257+00:00 host heroku web.1 - source=web.1 dyno=heroku.35930502.b9de5fce-44b7-4287-99a7-504519070cba sample#load_avg_1m=0.01`,
 		Expected: []string{
-			"heroku.dyno.load.avg.1m:0.010000|g|#type:web,source:web.1",
+			"heroku.dyno.load.avg.1m:0.010000|g|#source:web.1,type:web",
 		},
 	},
 	{


### PR DESCRIPTION
When `Heroku` router logs are converted into `DataDog` metrics  a `status` tag is added to the metrics. This is nice, as it's possible to create alerts for example for requests returning  status `401` .

However, there are lots of http status codes in the wild, and in some cases it would make sense to create alerts for whole families of codes. For instance, I'd like to be able to have an alert for all requests returning statuses like `401`, `409`, etc. To make it possible this app could generate a new tag - `statusFamily` which is appended based on `status` field from the router logs.

This PR tries to accomplish this. I have tried that with my setup and it seems to work fine, however:

1. I don't know `Go`, this is my "hello world", so a review would be great
2. I use pattern matching to check/extract the status code family, so it adds some time to the processing, but my guess is that it's not that important as this process is likely more `CPU` than `I/O` bound.
3. I have added sorting of tags when they are extracted, this is because without that the tests would fail. Test cases represent expected test results as strings, thus they assume that the tags are ordered. But `Go` maps don't guarantee iteration order and generated tag list order might be random. Alternative approach to the sorting would be to redesign the test cases, but it would increase complexity, so maybe it's not needed.