### PR TITLE
fix: update deps

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,10 +1,12 @@
-hash: 8789724a62f41fa5bd72030d75e697b5cab867112acf443a382f355c79c79581
-updated: 2018-01-10T14:59:21.534524+01:00
+hash: 508176bfbbac2de25feadd221e58941b3262b4d6e7d84af47851874fbbd69ce3
+updated: 2018-01-11T10:59:02.026208+01:00
 imports:
 - name: github.com/DataDog/datadog-go
   version: 0ddda6bee21174ef6c4873647cb0d6ec9cba996f
   subpackages:
   - statsd
+- name: github.com/gin-contrib/sse
+  version: 22d885f9ecc78bf4ee5d72b937e4bbcdc58e8cae
 - name: github.com/gin-gonic/gin
   version: d459835d2b077e44f7c9b453505ee29881d5d12d
   subpackages:
@@ -18,22 +20,17 @@ imports:
   version: 705849e307dd75c91728463dea5bfd08ef493e64
   subpackages:
   - hmetrics
+  - hmetrics/onload
 - name: github.com/kr/logfmt
   version: b84e30acd515aadc4b783ad4ff83aff3299bdfe0
-- name: github.com/manucorporat/sse
-  version: ee05b128a739a0fb76c7ebd3ae4810c1de808d6d
 - name: github.com/mattn/go-isatty
-  version: 56b76bdf51f7708750eac80fa38b952bb9f32639
+  version: 0360b2af4f38e8d38c7fce2a9f4e702702d73a39
 - name: github.com/Sirupsen/logrus
   version: ba1b36c82c5e05c4f912a88eab0dcd91a171688f
 - name: github.com/ugorji/go
   version: ccfe18359b55b97855cee1d3f74e5efbda4869dc
   subpackages:
   - codec
-- name: golang.org/x/net
-  version: f315505cf3349909cdf013ea56690da34e96a451
-  subpackages:
-  - context
 - name: golang.org/x/sys
   version: f64b50fbea64174967a8882830d621a18ee1548e
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -7,8 +7,10 @@ import:
 - package: github.com/Sirupsen/logrus
   version: ^0.11.0
 - package: github.com/gin-gonic/gin
-  version: ^1.1.0
+  version: ^1.2
 - package: github.com/kr/logfmt
 - package: github.com/heroku/x
   subpackages:
   - hmetrics
+- package: github.com/mattn/go-isatty
+  version: ~0.0.3


### PR DESCRIPTION
Fixing problem with deploy:

```
remote: [INFO]	--> Exporting gopkg.in/go-playground/validator.v8
remote: [INFO]	--> Exporting gopkg.in/yaml.v2
remote: [INFO]	Replacing existing vendor dependencies
remote: -----> Running: go install -v -tags heroku .
remote: vendor/github.com/gin-gonic/gin/context.go:19:2: cannot find package "github.com/gin-contrib/sse" in any of:
remote: 	/tmp/tmp.q63SpMxn2u/.go/src/github.com/apiaryio/heroku-datadog-drain-golang/vendor/github.com/gin-gonic/gin/vendor/github.com/gin-contrib/sse (vendor tree)
remote: 	/tmp/tmp.q63SpMxn2u/.go/src/github.com/apiaryio/heroku-datadog-drain-golang/vendor/github.com/gin-contrib/sse
remote: 	/app/tmp/cache/go1.9.2/go/src/github.com/gin-contrib/sse (from $GOROOT)
remote: 	/tmp/tmp.q63SpMxn2u/.go/src/github.com/gin-contrib/sse (from $GOPATH)
remote:  !     Push rejected, failed to compile Go app.
remote:
remote:  !     Push failed
remote: Verifying deploy...
remote:
remote: !	Push rejected to apiary-datadog-drain-go.
remote:
To https://git.heroku.com/apiary-datadog-drain-go.git
 ! [remote rejected] master -> master (pre-receive hook declined)
error: failed to push some refs to 'https://git.heroku.com/apiary-datadog-drain-go.git'
```