### PR TITLE
feat: add support for router bytes metric

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -16,7 +16,7 @@ var statsdTests = []struct {
 	Expected []string
 }{
 	{
-		cnt: 2,
+		cnt: 3,
 		m: logMetrics{
 			routerMsg,
 			&app,
@@ -27,12 +27,14 @@ var statsdTests = []struct {
 				"path":    {"/foo", ""},
 				"connect": {"1", "ms"},
 				"service": {"37", "ms"},
-				"status": {"401", ""},
+				"status":  {"401", ""},
+				"bytes":   {"244000", ""},
 				"garbage": {"bar", ""},
 			},
 			events,
 		},
 		Expected: []string{
+			"prefix.heroku.router.response.bytes:244000.000000|h|#at:info,status:401,tag1,tag2,statusFamily:4xx",
 			"prefix.heroku.router.request.connect:1.000000|h|#at:info,status:401,tag1,tag2,statusFamily:4xx",
 			"prefix.heroku.router.request.service:37.000000|h|#at:info,status:401,tag1,tag2,statusFamily:4xx",
 		},
@@ -146,8 +148,7 @@ var statsdTests = []struct {
 			&app,
 			&tags,
 			&prefix,
-			map[string]logValue{
-			},
+			map[string]logValue{},
 			[]string{
 				"Release v1 created by foo@bar",
 			},
@@ -156,7 +157,6 @@ var statsdTests = []struct {
 			"_e{13,29}:app/api: test|Release v1 created by foo@bar|#tag1,tag2",
 		},
 	},
-
 }
 
 func TestStatsdClient(t *testing.T) {

--- a/server_test.go
+++ b/server_test.go
@@ -19,9 +19,10 @@ var fullTests = []struct {
 	Expected []string
 }{
 	{
-		cnt: 2,
+		cnt: 3,
 		Req: `255 <158>1 2015-04-02T11:52:34.520012+00:00 host heroku router - at=info method=POST path="/users" host=myapp.com request_id=c1806361-2081-42e7-a8aa-92b6808eac8e fwd="24.76.242.18" dyno=web.1 connect=1ms service=37ms status=201 bytes=828`,
 		Expected: []string{
+			"heroku.router.response.bytes:828.000000|h|#at:info,dyno:web.1,host:myapp.com,method:POST,path:/users,status:201,statusFamily:2xx",
 			"heroku.router.request.connect:1.000000|h|#at:info,dyno:web.1,host:myapp.com,method:POST,path:/users,status:201,statusFamily:2xx",
 			"heroku.router.request.service:37.000000|h|#at:info,dyno:web.1,host:myapp.com,method:POST,path:/users,status:201,statusFamily:2xx",
 		},


### PR DESCRIPTION
Add support for calculate bytes from responses - https://devcenter.heroku.com/articles/http-routing